### PR TITLE
Ingress update

### DIFF
--- a/helm/gsprestapi/Chart.yaml
+++ b/helm/gsprestapi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "latest"
 description: "Global Streamflow Prediction REST API"
 name: gsprestapi
-version: 0.2.12
+version: 0.2.13

--- a/helm/gsprestapi/values.yaml
+++ b/helm/gsprestapi/values.yaml
@@ -20,8 +20,7 @@ service:
 ingress:
   enabled: true
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production-issuer
-    acme.cert-manager.io/http01-edit-in-place: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/proxy-connect-timeout: 300s
     nginx.org/proxy-read-timeout: 300s
     nginx.org/proxy-send-timeout: 300s


### PR DESCRIPTION
I have updated the ingress annotation to use the letsencrypt issuer with DNS challenge (no more http-challenge pods to validate the domain, so should be smoother).

Cheers,
Manuel